### PR TITLE
:label: added type hints for iddefix core functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 **I**mpedance **D**etermination through **D**ifferential **E**volution **FI**tting and e**X**trapolation.
 
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 ![PyPI - Version](https://img.shields.io/pypi/v/IDDEFIX?style=flat-square&color=green)
 ![PyPI - License](https://img.shields.io/pypi/l/IDDEFIX?style=flat-square&color=pink)
 [![Documentation Status](https://readthedocs.org/projects/iddefix/badge/?version=latest)](https://iddefix.readthedocs.io/en/latest/?badge=latest)

--- a/iddefix/framework.py
+++ b/iddefix/framework.py
@@ -8,8 +8,10 @@ Created on Mon Mar 23 13:20:11 2020
 """
 
 from functools import partial
+from typing import Any, Callable, Sequence
 
 import numpy as np
+import numpy.typing as npt
 from scipy.optimize import minimize
 
 from .objectiveFunctions import ObjectiveFunctions as obj
@@ -19,21 +21,25 @@ from .solvers import Solvers
 from .uncertainties import get_uncertainties
 from .utils import compute_fft
 
+ArrayLike = npt.ArrayLike
+ParameterBounds = list[tuple[float, float]]
+ObjectiveCallable = Callable[..., float]
+
 
 class EvolutionaryAlgorithm:
     def __init__(
         self,
-        x_data,
-        y_data,
-        N_resonators,
-        parameterBounds,
-        plane="longitudinal",
-        fitFunction="impedance",
-        objectiveFunction=None,
-        wake_length=None,
-        sigma=None,
-        uncertainty_warning=0.2,
-    ):
+        x_data: ArrayLike,
+        y_data: ArrayLike,
+        N_resonators: int,
+        parameterBounds: ParameterBounds,
+        plane: str = "longitudinal",
+        fitFunction: str = "impedance",
+        objectiveFunction: ObjectiveCallable | str | None = None,
+        wake_length: float | None = None,
+        sigma: float | None = None,
+        uncertainty_warning: float = 0.2,
+    ) -> None:
         """
         Implements an evolutionary algorithm for fitting impedance models to data.
 
@@ -224,7 +230,7 @@ class EvolutionaryAlgorithm:
             self.frequency_data = x_data
             self.impedance_data = y_data
 
-    def check_y_data(self):
+    def check_y_data(self) -> None:
         """
         Small function to avoid 0 frequency leading to zero division when
         using resonators.
@@ -235,18 +241,18 @@ class EvolutionaryAlgorithm:
 
     def generate_Initial_Parameters(
         self,
-        parameterBounds,
-        objectiveFunction,
-        fitFunction,
-        x_values_data,
-        y_values_data,
-        maxiter=2000,
-        popsize=150,
-        mutation=(0.1, 0.5),
-        crossover_rate=0.8,
-        tol=0.01,
-        solver="scipy",
-    ):
+        parameterBounds: ParameterBounds,
+        objectiveFunction: ObjectiveCallable,
+        fitFunction: Callable[..., np.ndarray],
+        x_values_data: ArrayLike,
+        y_values_data: ArrayLike,
+        maxiter: int = 2000,
+        popsize: int = 150,
+        mutation: tuple[float, float] = (0.1, 0.5),
+        crossover_rate: float = 0.8,
+        tol: float = 0.01,
+        solver: str = "scipy",
+    ) -> tuple[np.ndarray, str]:
         """
         Generates initial parameter estimates using a
         Differential Evolution (DE) solver.
@@ -336,7 +342,14 @@ class EvolutionaryAlgorithm:
 
         return solution, message
 
-    def run_cmaes(self, maxiter=1000, popsize=50, sigma=0.6, verbose=False, **kwargs):
+    def run_cmaes(
+        self,
+        maxiter: int = 1000,
+        popsize: int = 50,
+        sigma: float = 0.6,
+        verbose: bool = False,
+        **kwargs: Any,
+    ) -> Any:
         """
         Runs the CMA-ES (Covariance Matrix Adaptation Evolution Strategy) algorithm
         from `pymoo` to optimize resonance parameters.
@@ -407,13 +420,13 @@ class EvolutionaryAlgorithm:
 
     def run_differential_evolution(
         self,
-        maxiter=2000,
-        popsize=15,
-        mutation=(0.1, 0.5),
-        crossover_rate=0.8,
-        tol=0.01,
-        solver="scipy",
-    ):
+        maxiter: int = 2000,
+        popsize: int = 15,
+        mutation: tuple[float, float] = (0.1, 0.5),
+        crossover_rate: float = 0.8,
+        tol: float = 0.01,
+        solver: str = "scipy",
+    ) -> None:
         """
         Runs the differential evolution (DE) algorithm to estimate optimal
         resonance parameters.
@@ -492,7 +505,11 @@ class EvolutionaryAlgorithm:
             uncertainties=self.evolutionParametersUncertainties,
         )
 
-    def run_minimization_algorithm(self, margin=[0.1, 0.1, 0.1], method="Nelder-Mead"):
+    def run_minimization_algorithm(
+        self,
+        margin: float | Sequence[float] = [0.1, 0.1, 0.1],
+        method: str = "Nelder-Mead",
+    ) -> None:
         """
         Runs a minimization algorithm to refine resonance parameters.
 
@@ -593,11 +610,11 @@ class EvolutionaryAlgorithm:
 
     def display_resonator_parameters(
         self,
-        params=None,
-        to_markdown=False,
-        uncertainties=None,
-        display_uncertainties=True,
-    ):
+        params: ArrayLike | None = None,
+        to_markdown: bool = False,
+        uncertainties: ArrayLike | None = None,
+        display_uncertainties: bool = True,
+    ) -> None:
         """
         Displays resonance parameters in a formatted table using ASCII characters.
 
@@ -698,7 +715,11 @@ class EvolutionaryAlgorithm:
 
             print("-" * 76)
 
-    def _compute_flagged_params_mask(self, params, uncertainties):
+    def _compute_flagged_params_mask(
+        self,
+        params: ArrayLike | None,
+        uncertainties: ArrayLike | None,
+    ) -> np.ndarray | None:
         """Compute boolean mask for parameters above relative uncertainty threshold."""
 
         if params is None or uncertainties is None:
@@ -718,7 +739,11 @@ class EvolutionaryAlgorithm:
 
         return np.isfinite(rel_unc) & (rel_unc >= threshold)
 
-    def _warn_large_uncertainties(self, params, uncertainties):
+    def _warn_large_uncertainties(
+        self,
+        params: ArrayLike | None,
+        uncertainties: ArrayLike | None,
+    ) -> None:
         """Print a warning if any parameter has a large relative uncertainty.
 
         The relative uncertainty is defined as ``abs(sigma / value)``. If this
@@ -746,7 +771,11 @@ class EvolutionaryAlgorithm:
             f"[!] Warning: {n_flagged} parameter(s) have relative uncertainty >= {threshold:.2f} (max {max_rel:.2f})."
         )
 
-    def get_wake(self, time_data=None, use_minimization=True):
+    def get_wake(
+        self,
+        time_data: ArrayLike | None = None,
+        use_minimization: bool = True,
+    ) -> np.ndarray:
         # Check for time data
         if time_data is None:
             if self.time_data is None:
@@ -777,7 +806,12 @@ class EvolutionaryAlgorithm:
 
         return wake_data
 
-    def get_wake_potential(self, time_data=None, sigma=None, use_minimization=True):
+    def get_wake_potential(
+        self,
+        time_data: ArrayLike | None = None,
+        sigma: float | None = None,
+        use_minimization: bool = True,
+    ) -> np.ndarray:
         # Check for time data
         if time_data is None:
             if self.time_data is None:
@@ -821,8 +855,10 @@ class EvolutionaryAlgorithm:
         return wake_potential_data
 
     def get_impedance_from_fitFunction(
-        self, frequency_data=None, use_minimization=True
-    ):
+        self,
+        frequency_data: ArrayLike | None = None,
+        use_minimization: bool = True,
+    ) -> np.ndarray:
         # Check for frequency data
         if frequency_data is None:
             if self.frequency_data is None:
@@ -843,8 +879,11 @@ class EvolutionaryAlgorithm:
         return impedance_data
 
     def get_impedance(
-        self, frequency_data=None, use_minimization=True, wakelength=None
-    ):
+        self,
+        frequency_data: ArrayLike | None = None,
+        use_minimization: bool = True,
+        wakelength: float | None = None,
+    ) -> np.ndarray:
         # Check for frequency data
         if frequency_data is None:
             if self.frequency_data is None:
@@ -881,8 +920,12 @@ class EvolutionaryAlgorithm:
         return impedance_data
 
     def get_impedance_from_fft(
-        self, time_data=None, wake_data=None, fmax=3e9, samples=1001
-    ):
+        self,
+        time_data: ArrayLike | None = None,
+        wake_data: ArrayLike | None = None,
+        fmax: float = 3e9,
+        samples: int = 1001,
+    ) -> tuple[np.ndarray, np.ndarray]:
         # Check for time data
         if time_data is None:
             if self.time_data is None:
@@ -909,24 +952,13 @@ class EvolutionaryAlgorithm:
 
         return f, Z
 
-    def compute_fft(self, time_data=None, wake_data=None, fmax=3e9, samples=1001):
-        # Check for time data - not override self
-        if time_data is None:
-            if self.time_data is None:
-                raise AttributeError("Provide time data array")
-            time_data = self.time_data
-
-        # Check for wake data - not override self
-        if wake_data is None:
-            if self.wake_data is None:
-                raise AttributeError("Provide wake data array")
-            wake_data = self.wake_data
-
-        compute_fft(time_data, wake_data, fmax, samples)
-
     def get_extrapolated_wake(
-        self, new_end_time=None, dt=None, time_data=None, use_minimization=True
-    ):
+        self,
+        new_end_time: float | None = None,
+        dt: float | None = None,
+        time_data: ArrayLike | None = None,
+        use_minimization: bool = True,
+    ) -> tuple[np.ndarray, np.ndarray]:
         # Check for time data
         if time_data is None:
             if self.time_data is None:
@@ -951,8 +983,13 @@ class EvolutionaryAlgorithm:
         return ext_time_data, ext_wake_data
 
     def save_txt(
-        self, f_name, x_data=None, y_data=None, x_name="X [-]", y_name="Y [-]"
-    ):
+        self,
+        f_name: str,
+        x_data: ArrayLike | None = None,
+        y_data: ArrayLike | None = None,
+        x_name: str = "X [-]",
+        y_name: str = "Y [-]",
+    ) -> None:
         """
         Saves x and y data to a text file in a two-column format.
 
@@ -1009,7 +1046,14 @@ class EvolutionaryAlgorithm:
         else:
             print("txt not saved, please provide x_data and y_data")
 
-    def read_txt(self, txt, skiprows=2, delimiter=None, usecols=None, as_dict=False):
+    def read_txt(
+        self,
+        txt: str,
+        skiprows: int = 2,
+        delimiter: str | None = None,
+        usecols: Sequence[int] | None = None,
+        as_dict: bool = False,
+    ) -> dict[Any, np.ndarray] | tuple[np.ndarray, np.ndarray]:
         """
         Reads data from an ASCII text file and returns it as a dictionary or tuple.
 

--- a/iddefix/objectiveFunctions.py
+++ b/iddefix/objectiveFunctions.py
@@ -7,13 +7,24 @@ Modified Tue 23 Sep @edelafue
 @author: sjoly
 """
 
+from typing import Callable
+
 import numpy as np
+import numpy.typing as npt
+
+ArrayLike = npt.ArrayLike
+FitCallable = Callable[[ArrayLike, dict[int, ArrayLike]], ArrayLike]
 
 from .utils import pars_to_dict
 
 
 class ObjectiveFunctions:
-    def sumOfSquaredError(parameters, fitFunction, x, y):
+    def sumOfSquaredError(
+        parameters: ArrayLike,
+        fitFunction: FitCallable,
+        x: ArrayLike,
+        y: ArrayLike,
+    ) -> float:
         """Calculates the sum of squared errors (SSE) for a given fit function.
 
         This function computes the SSE between the predicted values from a fit
@@ -38,7 +49,12 @@ class ObjectiveFunctions:
         )
         return squared_error
 
-    def sumOfSquaredErrorReal(parameters, fitFunction, x, y):
+    def sumOfSquaredErrorReal(
+        parameters: ArrayLike,
+        fitFunction: FitCallable,
+        x: ArrayLike,
+        y: ArrayLike,
+    ) -> float:
         """Calculates the real sum of squared errors (SSE) for a given fit function.
 
         This function computes the SSE between the predicted values from a fit
@@ -61,7 +77,12 @@ class ObjectiveFunctions:
         squared_error = np.nansum((y.real - predicted_y.real) ** 2)
         return squared_error
 
-    def sumOfSquaredErrorAbs(parameters, fitFunction, x, y):
+    def sumOfSquaredErrorAbs(
+        parameters: ArrayLike,
+        fitFunction: FitCallable,
+        x: ArrayLike,
+        y: ArrayLike,
+    ) -> float:
         """Calculates the magnitude-based sum of squared errors (SSE).
 
         This function computes the SSE between the magnitudes of the predicted
@@ -83,7 +104,12 @@ class ObjectiveFunctions:
         squared_error = np.nansum((np.abs(y) - np.abs(predicted_y)) ** 2)
         return squared_error
 
-    def logsumOfSquaredError(parameters, fitFunction, x, y):
+    def logsumOfSquaredError(
+        parameters: ArrayLike,
+        fitFunction: FitCallable,
+        x: ArrayLike,
+        y: ArrayLike,
+    ) -> float:
         """Calculates the sum of log squared errors for a fit function.
 
         This function computes the log squared errors between the predicted
@@ -107,7 +133,12 @@ class ObjectiveFunctions:
         )
         return log_squared_error
 
-    def logsumOfSquaredErrorReal(parameters, fitFunction, x, y):
+    def logsumOfSquaredErrorReal(
+        parameters: ArrayLike,
+        fitFunction: FitCallable,
+        x: ArrayLike,
+        y: ArrayLike,
+    ) -> float:
         """Calculates the real sum of log squared errors for a given fit function.
 
         This function computes the real log squared errors between the predicted values
@@ -130,7 +161,13 @@ class ObjectiveFunctions:
         log_squared_error = np.nansum(np.log((y.real - predicted_y.real) ** 2))
         return log_squared_error
 
-    def logsumOfSquaredErrorAbs(parameters, fitFunction, x, y, eps=1e-12):
+    def logsumOfSquaredErrorAbs(
+        parameters: ArrayLike,
+        fitFunction: FitCallable,
+        x: ArrayLike,
+        y: ArrayLike,
+        eps: float = 1e-12,
+    ) -> float:
         """Calculates the magnitude-based sum of log squared errors.
 
         This function computes the log of squared errors between the magnitudes

--- a/iddefix/resonatorFormulas.py
+++ b/iddefix/resonatorFormulas.py
@@ -6,15 +6,27 @@ Created on Mon Mar 23 13:20:11 2020
 @author: sjoly
 """
 
+from typing import Sequence
+
 import numpy as np
+import numpy.typing as npt
 from scipy import special as sp
 
 from .utils import pars_to_dict
 
+ArrayLike = npt.ArrayLike
+ParameterDict = dict[int, Sequence[float]]
+ParsType = ParameterDict | ArrayLike
+
 
 class Wakes:
     # Longitudinal and transverse wake functions
-    def Resonator_longitudinal_wake(times, Rs, Q, resonant_frequency):
+    def Resonator_longitudinal_wake(
+        times: ArrayLike,
+        Rs: float,
+        Q: float,
+        resonant_frequency: float,
+    ) -> np.ndarray:
         """Calculates the longitudinal wake function of a resonator.
 
         This function calculates the longitudinal wake function of a resonator
@@ -85,7 +97,12 @@ class Wakes:
 
         return Wl
 
-    def Resonator_transverse_wake(times, Rs, Q, resonant_frequency):
+    def Resonator_transverse_wake(
+        times: ArrayLike,
+        Rs: float,
+        Q: float,
+        resonant_frequency: float,
+    ) -> np.ndarray:
         """Calculates the longitudinal wake function of a resonator.
 
         This function calculates the transverse wake function of a resonator
@@ -141,7 +158,7 @@ class Wakes:
 
         return Wt
 
-    def n_Resonator_longitudinal_wake(times, pars):
+    def n_Resonator_longitudinal_wake(times: ArrayLike, pars: ParsType) -> np.ndarray:
         """Calculates the combined longitudinal wake function of multiple resonators.
 
         This function calculates the total longitudinal wake function induced by a system
@@ -194,7 +211,7 @@ class Wakes:
         )
         return Wl
 
-    def n_Resonator_transverse_wake(times, pars):
+    def n_Resonator_transverse_wake(times: ArrayLike, pars: ParsType) -> np.ndarray:
         """Calculates the combined transverse wake function of multiple resonators.
 
         This function calculates the total transverse wake function induced by a system
@@ -249,8 +266,13 @@ class Wakes:
 
     # Longitudinal and transverse wake potentials
     def Resonator_longitudinal_wake_potential(
-        times, Rs, Q, resonant_frequency, sigma=1e-10, use_mpmath=False
-    ):
+        times: ArrayLike,
+        Rs: float,
+        Q: float,
+        resonant_frequency: float,
+        sigma: float = 1e-10,
+        use_mpmath: bool = False,
+    ) -> np.ndarray:
         """
         Single resonator wake potential (longitudinal) for a Gaussian bunch of line density.
 
@@ -324,7 +346,11 @@ class Wakes:
 
         return W
 
-    def n_Resonator_longitudinal_wake_potential(times, pars, sigma=1e-10):
+    def n_Resonator_longitudinal_wake_potential(
+        times: ArrayLike,
+        pars: ParsType,
+        sigma: float = 1e-10,
+    ) -> np.ndarray:
         if type(pars) is dict:
             dict_params = pars
         else:
@@ -337,8 +363,13 @@ class Wakes:
         return Wpl
 
     def Resonator_transverse_wake_potential(
-        times, Rs, Q, resonant_frequency, sigma=1e-10, use_mpmath=False
-    ):
+        times: ArrayLike,
+        Rs: float,
+        Q: float,
+        resonant_frequency: float,
+        sigma: float = 1e-10,
+        use_mpmath: bool = False,
+    ) -> np.ndarray:
         """
         Single resonator wake potential (transverse) for a Gaussian bunch of line density.
 
@@ -410,7 +441,11 @@ class Wakes:
 
         return W
 
-    def n_Resonator_transverse_wake_potential(times, pars, sigma=1e-10):
+    def n_Resonator_transverse_wake_potential(
+        times: ArrayLike,
+        pars: ParsType,
+        sigma: float = 1e-10,
+    ) -> np.ndarray:
         if type(pars) is dict:
             dict_params = pars
         else:
@@ -426,8 +461,12 @@ class Wakes:
 class Impedances:
     # Longitudinal and transverse impedance functions
     def Resonator_longitudinal_imp(
-        frequencies, Rs, Q, resonant_frequency, wake_length=None
-    ):
+        frequencies: ArrayLike,
+        Rs: float,
+        Q: float,
+        resonant_frequency: float,
+        wake_length: float | None = None,
+    ) -> np.ndarray:
         """Calculates the longitudinal impedance of a resonator.
 
         This function calculates the longitudinal impedance of a resonator
@@ -540,8 +579,12 @@ class Impedances:
         return Zl
 
     def Resonator_transverse_imp(
-        frequencies, Rs, Q, resonant_frequency, wake_length=None
-    ):
+        frequencies: ArrayLike,
+        Rs: float,
+        Q: float,
+        resonant_frequency: float,
+        wake_length: float | None = None,
+    ) -> np.ndarray:
         """Calculates the transverse impedance of a resonator.
 
         This function calculates the transverse impedance of a resonator with shunt
@@ -653,7 +696,11 @@ class Impedances:
 
         return Zt
 
-    def n_Resonator_longitudinal_imp(frequencies, pars, wake_length=None):
+    def n_Resonator_longitudinal_imp(
+        frequencies: ArrayLike,
+        pars: ParsType,
+        wake_length: float | None = None,
+    ) -> np.ndarray:
         """Calculates the combined longitudinal impedance of multiple resonators.
 
         This function calculates the total longitudinal impedance of a system consisting
@@ -720,7 +767,11 @@ class Impedances:
 
         return Zl
 
-    def n_Resonator_transverse_imp(frequencies, pars, wake_length=None):
+    def n_Resonator_transverse_imp(
+        frequencies: ArrayLike,
+        pars: ParsType,
+        wake_length: float | None = None,
+    ) -> np.ndarray:
         """Calculates the combined transverse impedance of multiple resonators.
 
         This function calculates the total transverse impedance of a system consisting

--- a/iddefix/smartBoundDetermination.py
+++ b/iddefix/smartBoundDetermination.py
@@ -8,22 +8,26 @@ Created on Sat Dec  5 16:34:10 2020
 
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 from scipy.signal import find_peaks
+
+ArrayLike = npt.ArrayLike
+ParameterBounds = list[tuple[float, float]]
 
 
 class SmartBoundDetermination:
     def __init__(
         self,
-        frequency_data,
-        impedance_data,
-        minimum_peak_height=1.0,
-        threshold=None,
-        distance=None,
-        prominence=None,
-        Rs_bounds=[0.8, 10],
-        Q_bounds=[0.5, 5],
-        fres_bounds=[-0.01e9, +0.01e9],
-    ):
+        frequency_data: ArrayLike,
+        impedance_data: ArrayLike,
+        minimum_peak_height: float = 1.0,
+        threshold: float | None = None,
+        distance: float | None = None,
+        prominence: float | None = None,
+        Rs_bounds: list[float] = [0.8, 10],
+        Q_bounds: list[float] = [0.5, 5],
+        fres_bounds: list[float] = [-0.01e9, +0.01e9],
+    ) -> None:
         """
         Automatically determines parameter bounds for resonance fitting
         by detecting impedance peaks in frequency-domain data.
@@ -136,13 +140,13 @@ class SmartBoundDetermination:
 
     def find(
         self,
-        frequency_data=None,
-        impedance_data=None,
-        minimum_peak_height=None,
-        threshold=None,
-        distance=None,
-        prominence=None,
-    ):
+        frequency_data: ArrayLike | None = None,
+        impedance_data: ArrayLike | None = None,
+        minimum_peak_height: float | None = None,
+        threshold: float | None = None,
+        distance: float | None = None,
+        prominence: float | None = None,
+    ) -> ParameterBounds:
         """
         Identifies peaks in the impedance data and determines the bounds
         for fitting parameters based on the detected peaks.
@@ -277,7 +281,7 @@ class SmartBoundDetermination:
         self.parameterBounds = parameterBounds
         return parameterBounds
 
-    def inspect(self):
+    def inspect(self) -> None:
         plt.figure()
         plt.plot(self.frequency_data, self.impedance_data)
 
@@ -318,7 +322,11 @@ class SmartBoundDetermination:
 
         return None
 
-    def to_table(self, parameterBounds=None, to_markdown=False):
+    def to_table(
+        self,
+        parameterBounds: ParameterBounds | None = None,
+        to_markdown: bool = False,
+    ) -> None:
         """
         Displays resonance parameters in a formatted ASCII table.
 

--- a/iddefix/solvers.py
+++ b/iddefix/solvers.py
@@ -7,18 +7,23 @@ Created on Sat Dec  5 16:33:41 2020
 @contributor: edelafue, babreufig
 """
 
+from typing import Any, Callable
+
 import numpy as np
 from scipy.optimize import differential_evolution
 from tqdm import tqdm
 
+ParameterBounds = list[tuple[float, float]]
+MinimizationFunction = Callable[[np.ndarray], float]
+
 
 class ProgressBarCallback:
-    def __init__(self, max_generations, desc="Optimization"):
+    def __init__(self, max_generations: int, desc: str = "Optimization") -> None:
         self.max_generations = max_generations
         self.current_generation = 0
         self.pbar = tqdm(total=max_generations, desc=desc, unit="gen")
 
-    def __call__(self, *args):
+    def __call__(self, *args: Any) -> bool | None:
         # --- scipy differential_evolution: (xk, convergence) ---
         if len(args) == 2 and not hasattr(args[0], "evaluator"):
             xk, convergence = args
@@ -44,11 +49,11 @@ class ProgressBarCallback:
 
             self.pbar.set_postfix({"conv": f"{(100 * (convergence)):6.1f} %"})
 
-    def close(self):
+    def close(self) -> None:
         self.pbar.close()
 
 
-def stop_criterion(solver):
+def stop_criterion(solver: Any) -> float:
     """Stopping criterion used in SciPy's differential evolution.
 
     Based on the criterion used in
@@ -68,15 +73,15 @@ def stop_criterion(solver):
 
 class Solvers:
     def run_scipy_solver(
-        parameterBounds,
-        minimization_function,
-        maxiter=2000,
-        popsize=150,
-        mutation=(0.1, 0.5),
-        crossover_rate=0.8,
-        tol=0.01,
+        parameterBounds: ParameterBounds,
+        minimization_function: MinimizationFunction,
+        maxiter: int = 2000,
+        popsize: int = 150,
+        mutation: tuple[float, float] = (0.1, 0.5),
+        crossover_rate: float = 0.8,
+        tol: float = 0.01,
         **kwargs,
-    ):
+    ) -> tuple[np.ndarray, str]:
         """Run SciPy's ``differential_evolution`` to minimize a function.
 
         All arguments are detailed in the SciPy documentation:
@@ -127,15 +132,15 @@ class Solvers:
         return solution, message
 
     def run_pyfde_solver(
-        parameterBounds,
-        minimization_function,
-        maxiter=2000,
-        popsize=150,
-        mutation=(0.45),
-        crossover_rate=0.8,
-        tol=0.01,
+        parameterBounds: ParameterBounds,
+        minimization_function: MinimizationFunction,
+        maxiter: int = 2000,
+        popsize: int = 150,
+        mutation: float = 0.45,
+        crossover_rate: float = 0.8,
+        tol: float = 0.01,
         **kwargs,
-    ):
+    ) -> tuple[np.ndarray, str]:
         """
         Runs the pyfde ClassicDE solver to minimize a given function.
 
@@ -182,13 +187,13 @@ class Solvers:
         return solution, message
 
     def run_pyfde_jade_solver(
-        parameterBounds,
-        minimization_function,
-        maxiter=2000,
-        popsize=150,
-        tol=0.01,
+        parameterBounds: ParameterBounds,
+        minimization_function: MinimizationFunction,
+        maxiter: int = 2000,
+        popsize: int = 150,
+        tol: float = 0.01,
         **kwargs,
-    ):
+    ) -> tuple[np.ndarray, str]:
         """
         Runs the pyfde JADE solver to minimize a given function.
 
@@ -233,14 +238,14 @@ class Solvers:
         return solution, message
 
     def run_pymoo_cmaes_solver(
-        parameterBounds,
-        minimization_function,
-        sigma=0.1,
-        maxiter=None,  # default: 100 + 150 * (N+3)**2 // popsize**0.5
-        popsize=None,  # defaul: 4 + int(3 * np.log(len(parameterBounds)))
-        verbose=False,
+        parameterBounds: ParameterBounds,
+        minimization_function: MinimizationFunction,
+        sigma: float = 0.1,
+        maxiter: int | None = None,  # default: 100 + 150 * (N+3)**2 // popsize**0.5
+        popsize: int | None = None,  # defaul: 4 + int(3 * np.log(len(parameterBounds)))
+        verbose: bool = False,
         **kwargs,
-    ):
+    ) -> tuple[np.ndarray, str, Any]:
         """
         Runs the pymoo CMAES solver to minimize a given function.
 
@@ -267,11 +272,18 @@ class Solvers:
                         """)
 
         class OptimizationProblem(Problem):
-            def __init__(self, objective_function, n_var, n_obj, xl, xu):
+            def __init__(
+                self,
+                objective_function: MinimizationFunction,
+                n_var: int,
+                n_obj: int,
+                xl: list[float],
+                xu: list[float],
+            ) -> None:
                 super().__init__(n_var=n_var, n_obj=n_obj, xl=xl, xu=xu)
                 self.objective_function = objective_function
 
-            def _evaluate(self, x, out):
+            def _evaluate(self, x: np.ndarray, out: dict[str, Any]) -> None:
                 out["F"] = [self.objective_function(xi) for xi in x]
 
         problem = OptimizationProblem(

--- a/iddefix/uncertainties.py
+++ b/iddefix/uncertainties.py
@@ -1,11 +1,22 @@
+from typing import Callable
+
 import numpy as np
+import numpy.typing as npt
 from scipy.linalg import svd
 from scipy.optimize._numdiff import approx_derivative
 
 import iddefix
 
+ArrayLike = npt.ArrayLike
+FitCallable = Callable[[ArrayLike, dict[int, ArrayLike]], ArrayLike]
 
-def StackedResiduals(parameters, x, fitFunction, y):
+
+def StackedResiduals(
+    parameters: ArrayLike,
+    x: ArrayLike,
+    fitFunction: FitCallable,
+    y: ArrayLike,
+) -> np.ndarray:
     """The stacked residuals (real and imaginary parts).
 
     This function takes the parameters obtained from the Differential Evolution or
@@ -34,7 +45,12 @@ def StackedResiduals(parameters, x, fitFunction, y):
     return residuals
 
 
-def build_jacobian(parameters, fitFunction, x, y):
+def build_jacobian(
+    parameters: ArrayLike,
+    fitFunction: FitCallable,
+    x: ArrayLike,
+    y: ArrayLike,
+) -> np.ndarray:
     """Build the Jacobian of the system.
 
     This function takes the parameters obtained from the Differential Evolution or
@@ -64,7 +80,12 @@ def build_jacobian(parameters, fitFunction, x, y):
     return jac
 
 
-def get_uncertainties(parameters, fitFunction, x, y):
+def get_uncertainties(
+    parameters: ArrayLike,
+    fitFunction: FitCallable,
+    x: ArrayLike,
+    y: ArrayLike,
+) -> np.ndarray:
     r"""Compute the parameter uncertainties of the results of the Differential
     Evolution or minimization algorithm.
 

--- a/iddefix/utils.py
+++ b/iddefix/utils.py
@@ -1,8 +1,16 @@
+from typing import Callable
+
 import numpy as np
+import numpy.typing as npt
 from scipy.constants import c as c_light
 
+ArrayLike = npt.ArrayLike
+NumericArray = npt.NDArray[np.float64]
+ComplexArray = npt.NDArray[np.complex128]
+ParameterDict = dict[int, ArrayLike]
 
-def pars_to_dict(pars):
+
+def pars_to_dict(pars: ArrayLike) -> dict[int, ArrayLike]:
     """Converts a list of parameters into a dictionary of parameter groups.
 
     This function takes a list of parameters `pars` and groups them into
@@ -31,7 +39,12 @@ def pars_to_dict(pars):
     return grouped_parameters
 
 
-def compute_fft(data_time, data_wake, fmax=3e9, samples=1001):
+def compute_fft(
+    data_time: ArrayLike,
+    data_wake: ArrayLike,
+    fmax: float = 3e9,
+    samples: int = 1001,
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Compute the Fourier transform of a wake and return the frequencies
     and impedance values within a specified frequency range.
@@ -86,7 +99,12 @@ def compute_fft(data_time, data_wake, fmax=3e9, samples=1001):
     return f, Z
 
 
-def compute_convolution(data_time, data_wake, sigma, kernel="numpy"):
+def compute_convolution(
+    data_time: ArrayLike,
+    data_wake: ArrayLike,
+    sigma: float,
+    kernel: str = "numpy",
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Compute the convolution of a wake function with a Gaussian bunch profile.
 
@@ -135,8 +153,12 @@ def compute_convolution(data_time, data_wake, sigma, kernel="numpy"):
 
 
 def compute_deconvolution(
-    data_time, data_wake_potential, sigma, fmax=3e9, samples=1001
-):
+    data_time: ArrayLike,
+    data_wake_potential: ArrayLike,
+    sigma: float,
+    fmax: float = 3e9,
+    samples: int = 1001,
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Deconvolve a wake potential with a Gaussian bunch profile to obtain the
     impedance spectrum.
@@ -193,7 +215,7 @@ def compute_deconvolution(
     return f, Z
 
 
-def gaussian_bunch(time, sigma):
+def gaussian_bunch(time: ArrayLike, sigma: float) -> np.ndarray:
     """
     Generate a Gaussian bunch profile.
 
@@ -215,7 +237,12 @@ def gaussian_bunch(time, sigma):
     )
 
 
-def gaussian_bunch_spectrum(time, sigma, fmax, samples=1001):
+def gaussian_bunch_spectrum(
+    time: ArrayLike,
+    sigma: float,
+    fmax: float,
+    samples: int = 1001,
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Generate a Gaussian bunch profile.
 
@@ -245,11 +272,17 @@ def gaussian_bunch_spectrum(time, sigma, fmax, samples=1001):
     return f[mask], lambdaf[mask]
 
 
-def interpolation_error_abs(func_output, interpolant_output):
+def interpolation_error_abs(
+    func_output: ArrayLike,
+    interpolant_output: ArrayLike,
+) -> np.ndarray:
     return np.abs(func_output - interpolant_output)
 
 
-def interpolation_error_rms(func_output, interpolant_output):
+def interpolation_error_rms(
+    func_output: ArrayLike,
+    interpolant_output: ArrayLike,
+) -> np.ndarray:
     error = interpolant_output - func_output
     squared_error = error**2
     mean_squared_error = np.mean(
@@ -260,14 +293,14 @@ def interpolation_error_rms(func_output, interpolant_output):
 
 
 def compute_ineffint(
-    data_freq,
-    data_impedance,
-    times=np.linspace(1e-11, 50e-9, 1000),
-    adaptative=True,
-    interpolation="linear",
-    plane="longitudinal",
-    error="Abs",
-):
+    data_freq: ArrayLike,
+    data_impedance: ArrayLike,
+    times: ArrayLike = np.linspace(1e-11, 50e-9, 1000),
+    adaptative: bool = True,
+    interpolation: str = "linear",
+    plane: str = "longitudinal",
+    error: str = "Abs",
+) -> tuple[ArrayLike, np.ndarray]:
     try:
         import neffint
     except Exception:
@@ -329,14 +362,14 @@ def compute_ineffint(
 
 
 def compute_neffint(
-    data_time,
-    data_wake,
-    frequencies=np.linspace(1, 5e9, 1000),
-    adaptative=True,
-    interpolation="linear",
-    plane="longitudinal",
-    error="abs",
-):
+    data_time: ArrayLike,
+    data_wake: ArrayLike,
+    frequencies: ArrayLike = np.linspace(1, 5e9, 1000),
+    adaptative: bool = True,
+    interpolation: str = "linear",
+    plane: str = "longitudinal",
+    error: str = "abs",
+) -> tuple[ArrayLike, np.ndarray]:
     try:
         import neffint
     except Exception:


### PR DESCRIPTION
## 📝 Pull Request Summary
<!-- Briefly describe what this PR does and why it's needed. -->
Introducing typehints & adopting `ty`: https://docs.astral.sh/ty/

## 🔧 Changes Made
<!-- List the key changes introduced in this PR. -->

This pull request focuses on improving type safety and code clarity throughout the codebase by adding type annotations to function signatures, introducing type aliases, and updating docstrings accordingly. Additionally, it makes minor improvements to documentation and code structure.

**Type Annotations and Type Safety Improvements:**

* `iddefix/framework.py`, `iddefix/objectiveFunctions.py`, `iddefix/resonatorFormulas.py`: Added detailed type annotations to all major class methods and functions, including parameter and return types, to improve code readability, maintainability, and static analysis. Introduced type aliases such as `ArrayLike`, `ParameterBounds`, and others to clarify expected argument types. [[1]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3R11-R14) [[2]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3R24-R42) [[3]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L238-R255) [[4]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L339-R352) [[5]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L410-R429) [[6]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L495-R512) [[7]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L596-R617) [[8]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L701-R722) [[9]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L721-R746) [[10]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L749-R778) [[11]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L780-R814) [[12]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L824-R861) [[13]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L846-R886) [[14]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L884-R928) [[15]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L912-R961) [[16]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L954-R992) [[17]](diffhunk://#diff-6449bef9ca664d0f46b0964aad0ac86b493ecc6d87dc1001d27575f615cb75e3L1012-R1056) [[18]](diffhunk://#diff-9722070278aca69832b5e94c2ac8b28323e36a47ed0ce17ddc186dab20f28475R10-R27) [[19]](diffhunk://#diff-9722070278aca69832b5e94c2ac8b28323e36a47ed0ce17ddc186dab20f28475L41-R57) [[20]](diffhunk://#diff-9722070278aca69832b5e94c2ac8b28323e36a47ed0ce17ddc186dab20f28475L64-R85) [[21]](diffhunk://#diff-9722070278aca69832b5e94c2ac8b28323e36a47ed0ce17ddc186dab20f28475L86-R112) [[22]](diffhunk://#diff-9722070278aca69832b5e94c2ac8b28323e36a47ed0ce17ddc186dab20f28475L110-R141) [[23]](diffhunk://#diff-9722070278aca69832b5e94c2ac8b28323e36a47ed0ce17ddc186dab20f28475L133-R170) [[24]](diffhunk://#diff-ffd49fb846dd47f6663f5e47913ffb92e1e4233fd776755934987f9d9b192f8dR9-R29) [[25]](diffhunk://#diff-ffd49fb846dd47f6663f5e47913ffb92e1e4233fd776755934987f9d9b192f8dL88-R105) [[26]](diffhunk://#diff-ffd49fb846dd47f6663f5e47913ffb92e1e4233fd776755934987f9d9b192f8dL144-R161)

**Documentation and Usability:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9): Added a badge for the `ty` type checker to the documentation, reflecting the increased focus on type safety.

These changes collectively enhance the robustness of the code and make it easier for developers to understand and use the API correctly.

## ✅ Checklist
- [x] Code follows the project's style and guidelines
- N/A Added tests for new functionality
- [x] Updated documentation (mentioned in `docs/` or included in `examples/` and `notebooks/`)
- [x] Verified that changes do not break existing functionality (automatic tests passing)

## 📌 Related Issues / PRs
N/A
