### PR TITLE
Fix the way pars is supplied to single resonator formulas

### DIFF
--- a/iddefix/framework.py
+++ b/iddefix/framework.py
@@ -910,11 +910,11 @@ class EvolutionaryAlgorithm:
             )
         elif self.plane == "longitudinal" and self.N_resonators == 1:
             impedance_data = imp.Resonator_longitudinal_imp(
-                frequency_data, pars, wakelength
+                frequency_data, *pars, wakelength
             )
         elif self.plane == "transverse" and self.N_resonators == 1:
             impedance_data = imp.Resonator_transverse_imp(
-                frequency_data, pars, wakelength
+                frequency_data, *pars, wakelength
             )
 
         return impedance_data


### PR DESCRIPTION
## 📝 Pull Request Summary
For a single resonator, the helper function get_impedance() uses:
```
impedance_data = imp.Resonator_longitudinal_imp(
    frequency_data, pars, wakelength
) 
```
However, it is not called the same way as the n resonators variant imp.n_Resonator_longitudinal_imp()
The individual Rs, Q, and f_resonant are passed instead of a pars array.

## 🔧 Changes Made
Thankfully, it can easily be fixed by using a starred expression, see:
```
impedance_data = imp.Resonator_longitudinal_imp(
    frequency_data, *pars, wakelength
) 
```

## ✅ Checklist
- [X] Code follows the project's style and guidelines
- N/A Added tests for new functionality
- N/A Updated documentation (mentioned in `docs/` or included in `examples/` and `notebooks/`)
- [X] Verified that changes do not break existing functionality (automatic tests passing)

## 📌 Related Issues / PRs
